### PR TITLE
Add ci files for docker-etl

### DIFF
--- a/ci_job.yaml
+++ b/ci_job.yaml
@@ -1,0 +1,12 @@
+build-job-etl-graph:
+  docker:
+    - image: docker:stable-git
+  steps:
+    - checkout
+    - compare-branch:
+        pattern: ^jobs/etl-graph/
+    - setup_remote_docker:
+        version: 19.03.13
+    - run:
+        name: Build Docker image
+        command: docker build -t app:build jobs/etl-graph/

--- a/ci_job.yaml
+++ b/ci_job.yaml
@@ -1,8 +1,12 @@
+# As seen from the perpsective of https://github.com/mozilla/docker-etl
 build-job-etl-graph:
   docker:
     - image: docker:stable-git
   steps:
     - checkout
+    - run:
+        name: Checkout git submodules
+        command: git submodule update --init --recursive
     - compare-branch:
         pattern: ^jobs/etl-graph/
     - setup_remote_docker:

--- a/ci_workflow.yaml
+++ b/ci_workflow.yaml
@@ -1,0 +1,12 @@
+job-etl-graph:
+  jobs:
+    - build-job-etl-graph
+    - gcp-gcr/build-and-push-image:
+        context: data-eng-airflow-gcr
+        path: jobs/etl-graph/
+        image: etl-graph_docker_etl
+        requires:
+          - build-job-etl-graph
+        filters:
+          branches:
+            only: main


### PR DESCRIPTION
This supports https://github.com/mozilla/docker-etl/pull/4 by adding the necessary config for scheduling builds on docker-etl.

It may be useful to review what queries are being run. The utility function `run_query` runs queries by running them in a specified project (e.g. `moz-fx-data-shared-prod`) and writing them into a `etl-graph:intermediate` dataset as a destination table.

https://github.com/mozilla/etl-graph/blob/8c7adfc29bf4b774b44afe90ea0e287172537608/etl-graph/utils.py#L51-L89

This is run for two queries found in the resources directory: https://github.com/mozilla/etl-graph/tree/main/etl-graph/resources. They read from JOBS_BY_PROJECT.

https://github.com/mozilla/etl-graph/blob/8c7adfc29bf4b774b44afe90ea0e287172537608/etl-graph/resources/query_log_edges.sql#L18-L93

It's likely that I will have to manually grant airflow access to the project resources via terraform (writer access the buckets and bigquery editor permissions). 