### PR TITLE
Update docker-etl fragments with workspaces

### DIFF
--- a/ci_job.yaml
+++ b/ci_job.yaml
@@ -14,3 +14,7 @@ build-job-etl-graph:
     - run:
         name: Build Docker image
         command: docker build -t app:build jobs/etl-graph/
+    - persist_to_workspace:
+        root: jobs
+        paths:
+          - etl-graph

--- a/ci_workflow.yaml
+++ b/ci_workflow.yaml
@@ -2,6 +2,8 @@ job-etl-graph:
   jobs:
     - build-job-etl-graph
     - gcp-gcr/build-and-push-image:
+        attach-workspace: true
+        workspace-root: jobs/etl-graph
         context: data-eng-airflow-gcr
         path: jobs/etl-graph/
         image: etl-graph_docker_etl


### PR DESCRIPTION
> unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /home/circleci/project/jobs/etl-graph/Dockerfile: no such file or directory

https://app.circleci.com/pipelines/github/mozilla/docker-etl/80/workflows/c1db6a49-7737-45d1-96d6-233d1b5896aa/jobs/190

So this is not optimal, since the build-and-push job doesn't check out submodules. There are a couple of things that could be done:

- make a PR to https://github.com/CircleCI-Public/gcp-gcr-orb to add submodule checkouts
- create a custom job for building and pushing that uses gcp primitives
- try caching the checkout out repo inside of a workspace

I'm trying out the last option, since it seems the most straightforward. I also noticed that while looking through the documentation and code that we're building the container twice. 