### PR TITLE
Update workspace attach location

### DIFF
--- a/ci_workflow.yaml
+++ b/ci_workflow.yaml
@@ -3,7 +3,7 @@ job-etl-graph:
     - build-job-etl-graph
     - gcp-gcr/build-and-push-image:
         attach-workspace: true
-        workspace-root: jobs/etl-graph
+        workspace-root: jobs
         context: data-eng-airflow-gcr
         path: jobs/etl-graph/
         image: etl-graph_docker_etl


### PR DESCRIPTION
The workspace is being attached in the wrong directory. I ssh'ed into the machine to find the following directory structure: `jobs/etl-graph/etl-graph/...`. 

This is one of the horrors of debugging CI across two repositories. 

