### PR TITLE
Specify both path and docker-context

### DIFF
--- a/ci_workflow.yaml
+++ b/ci_workflow.yaml
@@ -5,7 +5,8 @@ job-etl-graph:
         attach-workspace: true
         workspace-root: jobs
         context: data-eng-airflow-gcr
-        path: jobs/etl-graph/
+        path: jobs/etl-graph
+        docker-context: jobs/etl-graph
         image: etl-graph_docker_etl
         requires:
           - build-job-etl-graph


### PR DESCRIPTION
Yet another minor configuration error:

```bash
...
Collecting pyyaml==5.3.1 (from -r requirements.txt (line 120))
  Downloading https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz (269kB)
Collecting regex==2020.11.13 (from -r requirements.txt (line 135))
  Downloading https://files.pythonhosted.org/packages/ea/e1/e046de6981d5b97d110b2bfeaed7129e3e3a0bda057f4ef215c33f84c27c/regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl (667kB)
Collecting toml==0.10.2 (from -r requirements.txt (line 178))
  Downloading https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
Collecting typed-ast==1.4.1 (from -r requirements.txt (line 182))
  Downloading https://files.pythonhosted.org/packages/5d/10/0c1e8aa723a2b0c4032e048d8e511df82c8a1262f0e1df5e4c54eb2613e9/typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl (737kB)
Collecting typing-extensions==3.7.4.3 (from -r requirements.txt (line 214))
  Downloading https://files.pythonhosted.org/packages/60/7a/e881b5abb54db0e6e671ab088d079c57ce54e8a01a3ca443f561ccadb37e/typing_extensions-3.7.4.3-py3-none-any.whl
Collecting importlib-metadata; python_version < "3.8" (from flake8==3.8.4->-r requirements.txt (line 22))
In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    importlib-metadata; python_version < "3.8" from https://files.pythonhosted.org/packages/f3/ed/da40116a204abb5c4dd1d929346d33e0d29cedb2cedd18ea98f0385dcd92/importlib_metadata-3.4.0-py3-none-any.whl#sha256=ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771 (from flake8==3.8.4->-r requirements.txt (line 22))
The command '/bin/sh -c pip3 install -r requirements.txt' returned a non-zero code: 1
```

This is weird, it looks like it's taking the `requirements.txt` from the docker-etl root. I believe that the repo is building using the `docker-etl` root as the build context, since when I ssh into the container and build the container from the etl-graph root, everything works as expected. This might be something that should be changed in the template (i.e. set the build context to the job root).